### PR TITLE
Ignore new Android multiplatform Kotlin target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .gradle
 build
 /reports
+
+# Kotlin
+.kotlin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changed:
 - Nothing yet!
 
 Fixed:
-- Nothing yet!
+- Do not attempt to configure the new Android Kotlin multiplatform Gradle plugin's Kotlin target as if it were a "plain" Kotlin JVM target.
 
 
 ## [0.1.1] - 2025-09-19

--- a/src/main/kotlin/com/jakewharton/testdistribution/TestDistributionPlugin.kt
+++ b/src/main/kotlin/com/jakewharton/testdistribution/TestDistributionPlugin.kt
@@ -17,7 +17,7 @@ import org.gradle.api.tasks.bundling.Zip
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation.Companion.TEST_COMPILATION_NAME
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 public class TestDistributionPlugin : Plugin<Project> {
 	override fun apply(project: Project) {
@@ -135,9 +135,7 @@ public class TestDistributionPlugin : Plugin<Project> {
 
 			val base = project.extensions.getByType(BasePluginExtension::class.java)
 			val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
-			kotlin.targets.configureEach { target ->
-				if (target.platformType != KotlinPlatformType.jvm) return@configureEach
-
+			kotlin.targets.withType(KotlinJvmTarget::class.java).configureEach { target ->
 				val name = target.name + "Test"
 				val nameUpper = name.replaceFirstChar(Char::uppercase)
 
@@ -146,8 +144,7 @@ public class TestDistributionPlugin : Plugin<Project> {
 				val testCompilation = target.compilations.named(TEST_COMPILATION_NAME)
 				val testClassesProvider = testCompilation.map { it.output.allOutputs }
 				val testDependenciesProvider = testCompilation.map {
-					it.runtimeDependencyFiles?.filter(File::isFile)
-						?: project.files()
+					it.runtimeDependencyFiles.filter(File::isFile)
 				}
 
 				val testJarProvider = project.tasks.register("jar$nameUpper", Jar::class.java) {

--- a/src/test/fixtures/plugin-kotlin-mpp-with-android/build.gradle
+++ b/src/test/fixtures/plugin-kotlin-mpp-with-android/build.gradle
@@ -1,0 +1,43 @@
+buildscript {
+	dependencies {
+		classpath "com.jakewharton.gradle:test-distribution-gradle-plugin:$testDistributionVersion"
+		classpath libs.kotlin.gradlePlugin
+		classpath libs.android.gradlePlugin
+	}
+
+	repositories {
+		maven {
+			url "file://${rootDir.absolutePath}/../../../../build/localMaven"
+		}
+		mavenCentral()
+		google()
+	}
+}
+
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.android.kotlin.multiplatform.library'
+apply plugin: 'com.jakewharton.test-distribution'
+
+kotlin {
+	android {
+		namespace = 'com.example'
+		compileSdk = 36
+		minSdk = 26
+	}
+
+	jvm()
+
+	linuxArm64()
+	linuxX64()
+	macosArm64()
+	macosX64()
+	mingwX64()
+
+	sourceSets {
+		commonTest {
+			dependencies {
+				implementation(libs.kotlin.test)
+			}
+		}
+	}
+}

--- a/src/test/fixtures/plugin-kotlin-mpp-with-android/settings.gradle
+++ b/src/test/fixtures/plugin-kotlin-mpp-with-android/settings.gradle
@@ -1,0 +1,12 @@
+dependencyResolutionManagement {
+	versionCatalogs {
+		libs {
+			from(files('../../../../gradle/libs.versions.toml'))
+		}
+	}
+
+	repositories {
+		mavenCentral()
+		google()
+	}
+}

--- a/src/test/fixtures/plugin-kotlin-mpp-with-android/src/commonMain/kotlin/com/example/add.kt
+++ b/src/test/fixtures/plugin-kotlin-mpp-with-android/src/commonMain/kotlin/com/example/add.kt
@@ -1,0 +1,3 @@
+package com.example
+
+fun add(a: Int, b: Int): Int = a + b

--- a/src/test/fixtures/plugin-kotlin-mpp-with-android/src/commonTest/kotlin/com/example/AddTest.kt
+++ b/src/test/fixtures/plugin-kotlin-mpp-with-android/src/commonTest/kotlin/com/example/AddTest.kt
@@ -1,0 +1,10 @@
+package com.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AddTest {
+	@Test fun simple() {
+		assertEquals(5, add(3, 2))
+	}
+}

--- a/src/test/kotlin/com/jakewharton/testdistribution/TestDistributionPluginFixtureTest.kt
+++ b/src/test/kotlin/com/jakewharton/testdistribution/TestDistributionPluginFixtureTest.kt
@@ -85,6 +85,27 @@ class TestDistributionPluginFixtureTest {
 		)
 	}
 
+	@Test fun pluginKotlinMppWithAndroid() {
+		val name = "plugin-kotlin-mpp-with-android"
+		val fixtureDir = File(fixturesDir, name)
+		createRunner(fixtureDir, "installJvmTest").build()
+
+		val installDir = fixtureDir.resolve("build/install/jvmTest")
+		assertThat(installDir).isDirectory()
+
+		val binaryFile = installDir.resolve("bin/$name-test")
+		assertThat(binaryFile.readText())
+			.contains("""org.junit.runner.JUnitCore "com.example.AddTest"""")
+
+		val libDir = installDir.resolve("lib")
+		assertThat(libDir.list()).containsAtLeast(
+			"$name-jvm.jar",
+			"$name-jvm-tests.jar",
+		)
+
+		// TODO We should build Android as well.
+	}
+
 	@Test fun pluginKotlinMppWithBurst() {
 		val name = "plugin-kotlin-mpp-with-burst"
 		val fixtureDir = File(fixturesDir, name)


### PR DESCRIPTION
We may support it eventually, but for now it was incorrectly being identified as a 'plain' Kotlin/JVM target.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
