### PR TITLE
Bump minimum-supported Gradle version to 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Added:
 - Nothing yet!
 
 Changed:
-- Nothing yet!
+- The minimum-supported Gradle version is now 9.0.
 
 Fixed:
 - Nothing yet!

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ apply plugin: 'com.jakewharton.test-distribution'
 This plugin relies on Gradle internal APIs.
 As such, certain versions of the plugin only work with certain versions of Gradle.
 
-| Gradle       | Plugin        |
-|--------------|---------------|
-| 8.10 - 9.1.0 | 0.1.0 - 0.2.0 |
+| Gradle        | Plugin                 |
+|---------------|------------------------|
+| 9.0.0 - 9.1.0 | 0.2.0 - 0.3.0-SNAPSHOT |
+| 8.10 - 8.14.3 | 0.1.0 - 0.2.0          |
 
 Gradle versions newer than those listed may be supported, but have not been tested.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
@@ -64,18 +65,18 @@ repositories {
 }
 
 tasks.withType(JavaCompile).configureEach { task ->
-	task.sourceCompatibility = '11'
-	task.targetCompatibility = '11'
+	task.sourceCompatibility = '17'
+	task.targetCompatibility = '17'
 }
 
 tasks.withType(KotlinJvmCompile).configureEach { task ->
 	task.compilerOptions {
 		// Ensure compatibility with old Gradle versions. Keep in sync with TestDistributionPlugin.kt.
-		apiVersion = KotlinVersion.KOTLIN_1_8
-		languageVersion = KotlinVersion.KOTLIN_1_8
-		jvmTarget = JvmTarget.JVM_11
-		freeCompilerArgs.add('-Xjdk-release=11')
-		freeCompilerArgs.add('-Xjvm-default=all')
+		apiVersion = KotlinVersion.KOTLIN_2_2
+		languageVersion = KotlinVersion.KOTLIN_2_2
+		jvmTarget = JvmTarget.JVM_17
+		jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
+		freeCompilerArgs.add('-Xjdk-release=17')
 	}
 }
 

--- a/src/main/kotlin/com/jakewharton/testdistribution/Android.kt
+++ b/src/main/kotlin/com/jakewharton/testdistribution/Android.kt
@@ -1,0 +1,101 @@
+package com.jakewharton.testdistribution
+
+import com.android.build.api.artifact.ScopedArtifact
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.HasHostTests
+import com.android.build.api.variant.ScopedArtifacts
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
+import org.gradle.api.plugins.BasePluginExtension
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.application.CreateStartScripts
+import org.gradle.api.tasks.bundling.Zip
+import org.gradle.jvm.tasks.Jar
+
+internal fun configureAndroidPlugin(project: Project, gradleSupport: GradleSupport) {
+	val base = project.extensions.getByType(BasePluginExtension::class.java)
+
+	val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
+	androidComponents.onVariants { variant ->
+		if (variant !is HasHostTests) return@onVariants
+
+		val variantUpperName = variant.name.replaceFirstChar(Char::uppercase)
+		for ((testUpperName, hostTest) in variant.hostTests) {
+			val testName = testUpperName.replaceFirstChar(Char::lowercase)
+			val name = variant.name + testUpperName
+			val nameUpper = variantUpperName + testUpperName
+
+			val dummyClassesProvider = project.tasks.register(
+				"internal${nameUpper}Classes",
+				ScopedArtifactDummyTask::class.java,
+			)
+			hostTest.artifacts
+				.forScope(ScopedArtifacts.Scope.ALL)
+				.use(dummyClassesProvider)
+				.toGet(
+					ScopedArtifact.CLASSES,
+					ScopedArtifactDummyTask::jars,
+					ScopedArtifactDummyTask::classDirs,
+				)
+
+			val testJarProvider = project.tasks.register("jar$nameUpper", Jar::class.java) {
+				it.from(dummyClassesProvider.flatMap(ScopedArtifactDummyTask::classDirs))
+				it.archiveAppendix.set(variant.name)
+				it.archiveClassifier.set(testName)
+			}
+
+			val testScriptsProvider =
+				project.tasks.register("scripts$nameUpper", CreateStartScripts::class.java) {
+					it.outputDir = project.layout.buildDirectory.dir("scripts/$nameUpper").get().asFile
+					it.applicationName = base.archivesName.get() + "-test"
+
+					it.classpath = project.objects.fileCollection()
+						.from(testJarProvider.map { it.outputs.files })
+						.from(dummyClassesProvider.flatMap { it.jars })
+
+					it.mainClass.set(
+						dummyClassesProvider.flatMap {
+							it.classDirs.zip(it.jars) { classDirs, jars ->
+								val testClasses = project.objects.fileTree()
+								for (classDir in classDirs) {
+									testClasses.from(classDir)
+								}
+
+								val testFqcns = gradleSupport.detectTestClassNames(
+									testClasses,
+									testClasses.files.toList(),
+									jars.map(RegularFile::getAsFile),
+								)
+								"org.junit.runner.JUnitCore ${testFqcns.joinToString(" ") { """"$it"""" }}"
+							}
+						},
+					)
+				}
+
+			val installProvider =
+				project.tasks.register("install${nameUpper}Distribution", Copy::class.java) {
+					it.group = "distribution"
+					it.description = "Installs $name as a distribution as-is."
+
+					it.into("bin") {
+						it.from(testScriptsProvider)
+					}
+					it.into("lib") {
+						it.from(testJarProvider)
+						it.from(dummyClassesProvider.flatMap { it.jars })
+					}
+					it.destinationDir = project.layout.buildDirectory.dir("install/$name").get().asFile
+				}
+
+			project.tasks.register("zip${nameUpper}Distribution", Zip::class.java) {
+				it.group = "distribution"
+				it.description = "Bundles $name as a distribution."
+
+				it.from(installProvider)
+				it.destinationDirectory.set(project.layout.buildDirectory.dir("dist"))
+				it.archiveAppendix.set(variant.name)
+				it.archiveClassifier.set(testName)
+			}
+		}
+	}
+}

--- a/src/main/kotlin/com/jakewharton/testdistribution/GradleSupport_9_0.kt
+++ b/src/main/kotlin/com/jakewharton/testdistribution/GradleSupport_9_0.kt
@@ -13,7 +13,7 @@ import org.gradle.api.internal.tasks.testing.detection.DefaultTestClassScanner
 import org.gradle.api.internal.tasks.testing.junit.JUnitDetector
 
 @Suppress("ClassName")
-internal class GradleSupport_8_10 : GradleSupport {
+internal class GradleSupport_9_0 : GradleSupport {
 	override fun detectTestClassNames(
 		testClasses: FileTree,
 		testClassDirectories: List<File>,

--- a/src/main/kotlin/com/jakewharton/testdistribution/TestDistributionPlugin.kt
+++ b/src/main/kotlin/com/jakewharton/testdistribution/TestDistributionPlugin.kt
@@ -1,14 +1,8 @@
 package com.jakewharton.testdistribution
 
-import com.android.build.api.artifact.ScopedArtifact
-import com.android.build.api.variant.AndroidComponentsExtension
-import com.android.build.api.variant.HasHostTests
-import com.android.build.api.variant.ScopedArtifacts
 import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.file.RegularFile
-import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.plugins.BasePluginExtension
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.application.CreateStartScripts
@@ -24,10 +18,11 @@ public class TestDistributionPlugin : Plugin<Project> {
 		// HEY! If you update the minimum-supported Gradle version check to see if the Kotlin language version
 		// can be bumped. See https://docs.gradle.org/current/userguide/compatibility.html#kotlin.
 		val gradleVersion = GradleVersion.current()
+		val gradleMinimum = GradleVersion.version("9.0")
 		val gradleSupport = when {
-			gradleVersion >= GradleVersion.version("8.10") -> GradleSupport_8_10()
+			gradleVersion >= gradleMinimum -> GradleSupport_9_0()
 			else -> {
-				error("JVM test distribution plugin requires Gradle 8.10 or newer. Found $gradleVersion")
+				error("Test distribution plugin requires $gradleMinimum or newer. Found $gradleVersion")
 			}
 		}
 
@@ -43,92 +38,14 @@ public class TestDistributionPlugin : Plugin<Project> {
 			}
 		}
 
-		val androidPluginHandler: (AppliedPlugin) -> Unit = {
+		project.pluginManager.withPlugin("com.android.application") {
 			gotPlugin = true
-
-			val base = project.extensions.getByType(BasePluginExtension::class.java)
-
-			val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
-			androidComponents.onVariants { variant ->
-				if (variant !is HasHostTests) return@onVariants
-
-				val variantUpperName = variant.name.replaceFirstChar(Char::uppercase)
-				for ((testUpperName, hostTest) in variant.hostTests) {
-					val testName = testUpperName.replaceFirstChar(Char::lowercase)
-					val name = variant.name + testUpperName
-					val nameUpper = variantUpperName + testUpperName
-
-					val dummyClassesProvider = project.tasks.register("internal${nameUpper}Classes", ScopedArtifactDummyTask::class.java)
-					hostTest.artifacts
-						.forScope(ScopedArtifacts.Scope.ALL)
-						.use(dummyClassesProvider)
-						.toGet(
-							ScopedArtifact.CLASSES,
-							ScopedArtifactDummyTask::jars,
-							ScopedArtifactDummyTask::classDirs,
-						)
-
-					val testJarProvider = project.tasks.register("jar$nameUpper", Jar::class.java) {
-						it.from(dummyClassesProvider.flatMap(ScopedArtifactDummyTask::classDirs))
-						it.archiveAppendix.set(variant.name)
-						it.archiveClassifier.set(testName)
-					}
-
-					val testScriptsProvider = project.tasks.register("scripts$nameUpper", CreateStartScripts::class.java) {
-						it.outputDir = project.layout.buildDirectory.dir("scripts/$nameUpper").get().asFile
-						it.applicationName = base.archivesName.get() + "-test"
-
-						it.classpath = project.objects.fileCollection()
-							.from(testJarProvider.map { it.outputs.files })
-							.from(dummyClassesProvider.flatMap { it.jars })
-
-						it.mainClass.set(
-							dummyClassesProvider.flatMap {
-								it.classDirs.zip(it.jars) { classDirs, jars ->
-									val testClasses = project.objects.fileTree()
-									for (classDir in classDirs) {
-										testClasses.from(classDir)
-									}
-
-									val testFqcns = gradleSupport.detectTestClassNames(
-										testClasses,
-										testClasses.files.toList(),
-										jars.map(RegularFile::getAsFile),
-									)
-									"org.junit.runner.JUnitCore ${testFqcns.joinToString(" ") { """"$it"""" }}"
-								}
-							},
-						)
-					}
-
-					val installProvider = project.tasks.register("install${nameUpper}Distribution", Copy::class.java) {
-						it.group = "distribution"
-						it.description = "Installs $name as a distribution as-is."
-
-						it.into("bin") {
-							it.from(testScriptsProvider)
-						}
-						it.into("lib") {
-							it.from(testJarProvider)
-							it.from(dummyClassesProvider.flatMap { it.jars })
-						}
-						it.destinationDir = project.layout.buildDirectory.dir("install/$name").get().asFile
-					}
-
-					project.tasks.register("zip${nameUpper}Distribution", Zip::class.java) {
-						it.group = "distribution"
-						it.description = "Bundles $name as a distribution."
-
-						it.from(installProvider)
-						it.destinationDirectory.set(project.layout.buildDirectory.dir("dist"))
-						it.archiveAppendix.set(variant.name)
-						it.archiveClassifier.set(testName)
-					}
-				}
-			}
+			configureAndroidPlugin(project, gradleSupport)
 		}
-		project.pluginManager.withPlugin("com.android.application", androidPluginHandler)
-		project.pluginManager.withPlugin("com.android.library", androidPluginHandler)
+		project.pluginManager.withPlugin("com.android.library") {
+			gotPlugin = true
+			configureAndroidPlugin(project, gradleSupport)
+		}
 
 		project.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
 			gotPlugin = true


### PR DESCRIPTION
This allows us to use Kotlin 2.2 and Java 17. The forthcoming Kotlin 2.3.0 will no longer support compiling to 1.8, so we must bump.

Closes #36 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
