### PR TITLE
Gradle 9.3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [Unreleased]: https://github.com/JakeWharton/test-distribution-gradle-plugin/compare/0.2.0...HEAD
 
 Added:
-- Support for Gradle 9.4.
+- Support for Gradle 9.3.
 - `org.gradle.java` plugin is now supported (the base plugin of the `java` and `java-library` plugins).
 - `org.jetbrains.kotlin.jvm` plugin is now supported.
 

--- a/gradle-support-9-3/build.gradle
+++ b/gradle-support-9-3/build.gradle
@@ -4,5 +4,5 @@ apply plugin: 'com.vanniktech.maven.publish'
 dependencies {
 	api project(':gradle-support')
 	compileOnly libs.kotlin.stdlib
-	compileOnly 'org.gradle.experimental:gradle-public-api:9.4.0-milestone-1'
+	compileOnly 'org.gradle.experimental:gradle-public-api:9.3.0'
 }

--- a/gradle-support-9-3/gradle.properties
+++ b/gradle-support-9-3/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=test-distribution-gradle-support-9-3

--- a/gradle-support-9-3/src/main/kotlin/com/jakewharton/testdistribution/GradleSupport_9_3.kt
+++ b/gradle-support-9-3/src/main/kotlin/com/jakewharton/testdistribution/GradleSupport_9_3.kt
@@ -12,7 +12,7 @@ import org.gradle.api.internal.tasks.testing.detection.DefaultTestScanner
 import org.gradle.api.internal.tasks.testing.junit.JUnitDetector
 
 @Suppress("ClassName")
-class GradleSupport_9_4 : GradleSupport {
+class GradleSupport_9_3 : GradleSupport {
 	override fun detectTestClassNames(
 		testClasses: FileTree,
 		testClassDirectories: List<File>,

--- a/gradle-support-9-4/gradle.properties
+++ b/gradle-support-9-4/gradle.properties
@@ -1,1 +1,0 @@
-POM_ARTIFACT_ID=test-distribution-gradle-support-9-4

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -30,7 +30,7 @@ tasks.named('validatePlugins') {
 
 dependencies {
 	implementation project(':gradle-support-9-1')
-	implementation project(':gradle-support-9-4')
+	implementation project(':gradle-support-9-3')
 
 	compileOnly libs.kotlin.gradlePlugin
 	compileOnly libs.android.gradlePlugin
@@ -70,7 +70,7 @@ buildConfig {
 tasks.named('test') {
 	dependsOn(':gradle-support:publishAllPublicationsToTestingRepository')
 	dependsOn(':gradle-support-9-1:publishAllPublicationsToTestingRepository')
-	dependsOn(':gradle-support-9-4:publishAllPublicationsToTestingRepository')
+	dependsOn(':gradle-support-9-3:publishAllPublicationsToTestingRepository')
 	dependsOn(':plugin:publishAllPublicationsToTestingRepository')
 	inputs.dir('src/test/fixtures')
 

--- a/plugin/src/main/kotlin/com/jakewharton/testdistribution/TestDistributionPlugin.kt
+++ b/plugin/src/main/kotlin/com/jakewharton/testdistribution/TestDistributionPlugin.kt
@@ -15,7 +15,7 @@ public class TestDistributionPlugin : Plugin<Project> {
 				error("Test distribution plugin requires $gradleMinimum or newer. Found $gradleVersion")
 			}
 
-			gradleVersion >= GradleVersion.version("9.4") -> GradleSupport_9_4()
+			gradleVersion >= GradleVersion.version("9.3") -> GradleSupport_9_3()
 
 			else -> GradleSupport_9_0()
 		}

--- a/plugin/src/test/kotlin/com/jakewharton/testdistribution/TestDistributionPluginFixtureTest.kt
+++ b/plugin/src/test/kotlin/com/jakewharton/testdistribution/TestDistributionPluginFixtureTest.kt
@@ -13,7 +13,12 @@ import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
 class TestDistributionPluginFixtureTest(
-	@param:TestParameter(LATEST_GRADLE_VERSION, MINIMUM_GRADLE_VERSION)
+	@param:TestParameter(
+		LATEST_GRADLE_VERSION,
+		"9.3.0",
+		"9.2.0",
+		MINIMUM_GRADLE_VERSION,
+	)
 	private val gradleVersion: String,
 ) {
 	@Test fun pluginAndroidApplication() {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,5 +2,5 @@ rootProject.name = 'test-distribution-gradle-plugin'
 
 include ':gradle-support'
 include ':gradle-support-9-1'
-include ':gradle-support-9-4'
+include ':gradle-support-9-3'
 include ':plugin'


### PR DESCRIPTION
Turns out the 9.4 support was actually needed for 9.3, we just didn't have test coverage for it.

Closes #73 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
