### PR TITLE
Add testing for Gradle 9.4 now that latest is 9.5

### DIFF
--- a/plugin/src/test/kotlin/com/jakewharton/testdistribution/TestDistributionPluginFixtureTest.kt
+++ b/plugin/src/test/kotlin/com/jakewharton/testdistribution/TestDistributionPluginFixtureTest.kt
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith
 class TestDistributionPluginFixtureTest(
 	@param:TestParameter(
 		LATEST_GRADLE_VERSION,
+		"9.4.0",
 		"9.3.0",
 		"9.2.0",
 		MINIMUM_GRADLE_VERSION,


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
