### PR TITLE
Fixed project capture when setting `mainClass` in PluginAndroid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/JakeWharton/test-distribution-gradle-plugin/compare/0.3.0...HEAD
 
-Nothing yet!
+Fixed:
+- Android distribution tasks are now compatible with configuration cache.
 
 
 ## [0.3.0] - 2026-01-016

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -67,7 +67,8 @@ buildConfig {
 	}
 }
 
-tasks.named('test') {
+tasks.withType(Test).configureEach {
+	maxHeapSize = '1g'
 	dependsOn(':gradle-support:publishAllPublicationsToTestingRepository')
 	dependsOn(':gradle-support-9-1:publishAllPublicationsToTestingRepository')
 	dependsOn(':gradle-support-9-3:publishAllPublicationsToTestingRepository')

--- a/plugin/src/main/kotlin/com/jakewharton/testdistribution/PluginAndroid.kt
+++ b/plugin/src/main/kotlin/com/jakewharton/testdistribution/PluginAndroid.kt
@@ -5,7 +5,7 @@ import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.HasHostTests
 import com.android.build.api.variant.ScopedArtifacts
 import org.gradle.api.Project
-import org.gradle.api.file.RegularFile
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.plugins.BasePluginExtension
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.application.CreateStartScripts
@@ -53,21 +53,19 @@ internal fun configureAndroidPlugin(project: Project, gradleSupport: GradleSuppo
 						.from(testJarProvider.map { it.outputs.files })
 						.from(dummyClassesProvider.flatMap { it.jars })
 
-					it.mainClass.set(
-						dummyClassesProvider.flatMap {
-							it.classDirs.zip(it.jars) { classDirs, jars ->
-								val testClasses = project.objects.fileTree()
-								for (classDir in classDirs) {
-									testClasses.from(classDir)
-								}
+					val testClasses = project.objects.fileCollection()
+						.from(dummyClassesProvider.flatMap(ScopedArtifactDummyTask::classDirs))
+					val testJars = project.objects.fileCollection()
+						.from(dummyClassesProvider.flatMap(ScopedArtifactDummyTask::jars))
 
-								val testFqcns = gradleSupport.detectTestClassNames(
-									testClasses,
-									testClasses.files.toList(),
-									jars.map(RegularFile::getAsFile),
-								).sorted()
-								"org.junit.runner.JUnitCore ${testFqcns.joinToString(" ") { """"$it"""" }}"
-							}
+					it.mainClass.set(
+						testClasses.elements.zip(testJars.elements) { classElements, jarElements ->
+							val testFqcns = gradleSupport.detectTestClassNames(
+								testClasses.asFileTree,
+								classElements.map(FileSystemLocation::getAsFile),
+								jarElements.map(FileSystemLocation::getAsFile),
+							).sorted()
+							"org.junit.runner.JUnitCore ${testFqcns.joinToString(" ") { """"$it"""" }}"
 						},
 					)
 				}

--- a/plugin/src/main/kotlin/com/jakewharton/testdistribution/PluginJvm.kt
+++ b/plugin/src/main/kotlin/com/jakewharton/testdistribution/PluginJvm.kt
@@ -4,12 +4,11 @@ import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
-import org.gradle.api.file.FileTree
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.plugins.BasePluginExtension
 import org.gradle.api.plugins.JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME
 import org.gradle.api.plugins.JavaPlugin.JAR_TASK_NAME
 import org.gradle.api.plugins.JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.application.CreateStartScripts
@@ -71,17 +70,17 @@ private fun finishKotlinPlugin(
 	val mainJarProvider = project.tasks.named(target.artifactsTaskName)
 
 	val testCompilation = target.compilations.named(TEST_COMPILATION_NAME)
-	val testClassesProvider = testCompilation.map { it.output.allOutputs.asFileTree }
-	val testDependenciesProvider = testCompilation.map {
-		it.runtimeDependencyFiles?.filter(File::isFile)
-	}
+	val testClasses = project.objects.fileCollection()
+		.from(testCompilation.map { it.output.allOutputs })
+	val testDependencies = project.objects.fileCollection()
+		.from(testCompilation.map { it.runtimeDependencyFiles?.filter(File::isFile) })
 
 	configureTasks(
 		project,
 		gradleSupport,
 		mainJarProvider,
-		testClassesProvider,
-		testDependenciesProvider,
+		testClasses,
+		testDependencies,
 		testJarProvider,
 		testScriptsProvider,
 		installProvider,
@@ -98,21 +97,21 @@ private fun finishJavaPlugin(
 	val mainJarProvider = project.tasks.named(JAR_TASK_NAME)
 
 	val testCompilation = project.tasks.named(COMPILE_TEST_JAVA_TASK_NAME)
-	val testClassesProvider = testCompilation.flatMap {
-		(it as JavaCompile).destinationDirectory.map { it.asFileTree }
-	}
-	val testDependenciesProvider = project.configurations.named(TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME).map { it.asFileTree }
+	val testClasses = project.objects.fileCollection()
+		.from(testCompilation.flatMap { (it as JavaCompile).destinationDirectory })
+	val testDependencies = project.objects.fileCollection()
+		.from(project.configurations.named(TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME))
 
 	testJarProvider.configure {
-		it.from(testClassesProvider)
+		it.from(testClasses)
 	}
 
 	configureTasks(
 		project,
 		gradleSupport,
 		mainJarProvider,
-		testClassesProvider,
-		testDependenciesProvider,
+		testClasses,
+		testDependencies,
 		testJarProvider,
 		testScriptsProvider,
 		installProvider,
@@ -123,8 +122,8 @@ private fun configureTasks(
 	project: Project,
 	gradleSupport: GradleSupport,
 	mainJarProvider: TaskProvider<Task>,
-	testClassesProvider: Provider<FileTree>,
-	testDependenciesProvider: Provider<out FileCollection>,
+	testClasses: FileCollection,
+	testDependencies: FileCollection,
 	testJarProvider: TaskProvider<Jar>,
 	testScriptsProvider: TaskProvider<CreateStartScripts>,
 	installProvider: TaskProvider<Copy>,
@@ -133,14 +132,14 @@ private fun configureTasks(
 		it.classpath = project.objects.fileCollection()
 			.from(mainJarProvider.map { it.outputs.files })
 			.from(testJarProvider.map { it.outputs.files })
-			.from(testDependenciesProvider)
+			.from(testDependencies)
 
 		it.mainClass.set(
-			testClassesProvider.zip(testDependenciesProvider) { testClasses, testDependencies ->
+			testClasses.elements.zip(testDependencies.elements) { classElements, dependencyElements ->
 				val testFqcns = gradleSupport.detectTestClassNames(
-					testClasses,
-					testClasses.files.toList(),
-					testDependencies.files.toList(),
+					testClasses.asFileTree,
+					classElements.map(FileSystemLocation::getAsFile),
+					dependencyElements.map(FileSystemLocation::getAsFile),
 				).sorted()
 				"org.junit.runner.JUnitCore ${testFqcns.joinToString(" ") { """"$it"""" }}"
 			},
@@ -154,7 +153,7 @@ private fun configureTasks(
 		it.into("lib") {
 			it.from(testJarProvider)
 			it.from(mainJarProvider)
-			it.from(testDependenciesProvider)
+			it.from(testDependencies)
 		}
 	}
 }

--- a/plugin/src/main/kotlin/com/jakewharton/testdistribution/PluginKmp.kt
+++ b/plugin/src/main/kotlin/com/jakewharton/testdistribution/PluginKmp.kt
@@ -2,6 +2,7 @@ package com.jakewharton.testdistribution
 
 import java.io.File
 import org.gradle.api.Project
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.plugins.BasePluginExtension
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.application.CreateStartScripts
@@ -21,13 +22,13 @@ internal fun configureKotlinMultiplatformPlugin(project: Project, gradleSupport:
 		val mainJarProvider = project.tasks.named(target.artifactsTaskName)
 
 		val testCompilation = target.compilations.named(TEST_COMPILATION_NAME)
-		val testClassesProvider = testCompilation.map { it.output.allOutputs }
-		val testDependenciesProvider = testCompilation.map {
-			it.runtimeDependencyFiles.filter(File::isFile)
-		}
+		val testClasses = project.objects.fileCollection()
+			.from(testCompilation.map { it.output.allOutputs })
+		val testDependencies = project.objects.fileCollection()
+			.from(testCompilation.map { it.runtimeDependencyFiles.filter(File::isFile) })
 
 		val testJarProvider = project.tasks.register("jar$nameUpper", Jar::class.java) {
-			it.from(testClassesProvider)
+			it.from(testClasses)
 			it.archiveAppendix.set(target.name)
 			it.archiveClassifier.set("tests")
 		}
@@ -39,14 +40,14 @@ internal fun configureKotlinMultiplatformPlugin(project: Project, gradleSupport:
 			it.classpath = project.objects.fileCollection()
 				.from(mainJarProvider.map { it.outputs.files })
 				.from(testJarProvider.map { it.outputs.files })
-				.from(testDependenciesProvider)
+				.from(testDependencies)
 
 			it.mainClass.set(
-				testClassesProvider.zip(testDependenciesProvider) { testClasses, testDependencies ->
+				testClasses.elements.zip(testDependencies.elements) { classElements, dependencyElements ->
 					val testFqcns = gradleSupport.detectTestClassNames(
 						testClasses.asFileTree,
-						testClasses.files.toList(),
-						testDependencies.files.toList(),
+						classElements.map(FileSystemLocation::getAsFile),
+						dependencyElements.map(FileSystemLocation::getAsFile),
 					).sorted()
 					"org.junit.runner.JUnitCore ${testFqcns.joinToString(" ") { """"$it"""" }}"
 				},
@@ -63,7 +64,7 @@ internal fun configureKotlinMultiplatformPlugin(project: Project, gradleSupport:
 			it.into("lib") {
 				it.from(testJarProvider)
 				it.from(mainJarProvider)
-				it.from(testDependenciesProvider)
+				it.from(testDependencies)
 			}
 			it.destinationDir = project.layout.buildDirectory.dir("install/$name").get().asFile
 		}

--- a/plugin/src/test/kotlin/com/jakewharton/testdistribution/TestDistributionPluginFixtureTest.kt
+++ b/plugin/src/test/kotlin/com/jakewharton/testdistribution/TestDistributionPluginFixtureTest.kt
@@ -211,7 +211,7 @@ class TestDistributionPluginFixtureTest(
 				*tasks,
 				"--stacktrace",
 				"--continue",
-				"--no-configuration-cache", // https://github.com/JakeWharton/test-distribution-gradle-plugin/issues/10
+				"--configuration-cache",
 				"--no-build-cache",
 				VERSION_PROPERTY,
 				VALIDATE_KOTLIN_METADATA,


### PR DESCRIPTION
Fixes #10 

Realized the other plugin test cases could already pass without any changes, so I wanted to make this as minimal of a change as I could. The reason PluginAndroid had caching issues was the project being captured when setting `mainClass` as the project can't be serialized.

I've moved the `classDir`/`jar` collections out of `zip` so the lambda only captures those collections and not `project`.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
